### PR TITLE
Feat/add eav

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 loans_for_good/__pycache__
+.coverage

--- a/loans_for_good/settings.py
+++ b/loans_for_good/settings.py
@@ -39,7 +39,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
-    'proposal'
+    'proposal',
+    'eav'
 ]
 
 MIDDLEWARE = [

--- a/loans_for_good/urls.py
+++ b/loans_for_good/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/proposal/', include('proposal.urls'))
 ]

--- a/proposal/admin.py
+++ b/proposal/admin.py
@@ -1,1 +1,15 @@
 from django.contrib import admin
+from eav.forms import BaseDynamicEntityForm
+from eav.admin import BaseEntityAdmin
+from .models import Proposal
+
+
+class ProposalAdminForm(BaseDynamicEntityForm):
+    model = Proposal
+
+
+class ProposalAdmin(BaseEntityAdmin):
+    model = ProposalAdminForm
+
+
+admin.register(Proposal, ProposalAdmin)

--- a/proposal/models.py
+++ b/proposal/models.py
@@ -1,5 +1,5 @@
+import eav
 from django.db import models
-
 # Create your models here.
 
 
@@ -7,3 +7,6 @@ class Proposal(models.Model):
     name = models.CharField(max_length=100)
     document = models.CharField(max_length=20)
     status = models.CharField(max_length=20)
+
+
+eav.register(Proposal)

--- a/proposal/serializers.py
+++ b/proposal/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from eav.models import Attribute
+
+
+class AttributeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Attribute
+        fields = ('name',)

--- a/proposal/tests.py
+++ b/proposal/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/proposal/tests/test_views.py
+++ b/proposal/tests/test_views.py
@@ -1,0 +1,23 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from eav.models import Attribute
+from proposal.serializers import AttributeSerializer
+
+
+class ProposalAttributesViewTestCase(APITestCase):
+    def setUp(self):
+        self.url = reverse('proposal:attributes')
+        self.attribute1 = Attribute.objects.create(
+            name='Attribute 1', datatype=Attribute.TYPE_TEXT)
+        self.attribute2 = Attribute.objects.create(
+            name='Attribute 2', datatype=Attribute.TYPE_TEXT)
+
+    def test_get_proposal_attributes(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+        serializer = AttributeSerializer(
+            [self.attribute1, self.attribute2], many=True)
+        self.assertEqual(response.data, serializer.data)

--- a/proposal/urls.py
+++ b/proposal/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from .views import ProposalAttributesView
+
+app_name = 'proposal'
+
+urlpatterns = [
+    path('attributes', ProposalAttributesView.as_view(), name='attributes'),
+]

--- a/proposal/views.py
+++ b/proposal/views.py
@@ -1,3 +1,15 @@
 from django.shortcuts import render
+from rest_framework import mixins
+from rest_framework import generics
+from .serializers import AttributeSerializer
+from eav.models import Attribute
 
 # Create your views here.
+
+
+class ProposalAttributesView(mixins.ListModelMixin, generics.GenericAPIView):
+    queryset = Attribute.objects.all()
+    serializer_class = AttributeSerializer
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ celery==5.2.7
 redis==4.5.5
 flake8==6.1.0
 autopep8==2.0.3
+django-eav2==1.4.0
+coverage==7.3.0


### PR DESCRIPTION
# Feature - Add `Entity Attribute Value` arch to the project

## Motivation
The goal of this PR is to add `EAV` arch to the project, more specific to `Proposal` model. We are doing that because we need to handle custom attributes to proposal.

## Files Changed
- `.gitignore`: Add `.coverage` to gitignore file
- `settings.py`: Add `eav` app to settings
- `urls.py`: Add `api/proposal` route to our project
- `admin.py`: Add proposal admin form to CRUD `eav` attributes
- `models.py`: Register `eav` to proposal
- `serializers.py`: Add `AttributeSerializer` 
- `test_views.py`: Add test to our `ProposalAttributesView`
- `views.py`: Add `ProposalAttributesView` 
- `requirements.txt`: Add `django-eav2` and `coverage`

## Coverage
![image](https://github.com/jsobralgitpush/lfg_backend/assets/63429525/4b01db82-d756-4e46-bafa-f9d2406af641)


## Reference
https://github.com/jazzband/django-eav2
